### PR TITLE
Migrated vaultSDK plugin from vaultSDK to udSDK

### DIFF
--- a/lib/auth/login.dart
+++ b/lib/auth/login.dart
@@ -14,10 +14,10 @@ class AuthDetails {
 }
 
 class LoginPage extends StatefulWidget {
-  LoginPage({Key key, this.vdkContext}) : super(key: key);
+  LoginPage({Key key, this.udContext}) : super(key: key);
 
   static const routeName = '/';
-  final Pointer<IntPtr> vdkContext;
+  final Pointer<IntPtr> udContext;
 
   @override
   _LoginPageState createState() => _LoginPageState();
@@ -36,7 +36,7 @@ class _LoginPageState extends State<LoginPage> {
     });
 
     final err =
-        UdContext.connect(widget.vdkContext, user.username, user.password);
+        UdContext.connect(widget.udContext, user.username, user.password);
 
     setState(() {
       _isLoading = false;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,7 +13,7 @@ void main() {
 }
 
 class MyApp extends StatelessWidget {
-  static Pointer<IntPtr> vdkContext = allocate();
+  static Pointer<IntPtr> udContext = allocate();
 
   // This widget is the root of your application.
   @override
@@ -39,7 +39,7 @@ class MyApp extends StatelessWidget {
         initialRoute: '/',
         routes: {
           LoginPage.routeName: (context) => LoginPage(
-                vdkContext: vdkContext,
+                udContext: udContext,
               ),
           MyHomePage.routeName: (context) =>
               MyHomePage(title: 'Flutter Demo Home Page')

--- a/lib/util/Result.dart
+++ b/lib/util/Result.dart
@@ -9,20 +9,20 @@ abstract class Result<T> {
   void setErrorMessage();
 }
 
-class AuthResult extends Result<vdkError> {
-  vdkError value;
+class AuthResult extends Result<udError> {
+  udError value;
   String message;
 
   AuthResult() : super();
 
   bool get error {
     if (value == null) return false;
-    return value != vdkError.vE_Success;
+    return value != udError.udE_Success;
   }
 
   bool get ok {
     if (value == null) return false;
-    return value == vdkError.vE_Success;
+    return value == udError.udE_Success;
   }
 
   // Returns a string representation of the vdkError value
@@ -34,20 +34,20 @@ class AuthResult extends Result<vdkError> {
 
   void setErrorMessage() {
     switch (this.value) {
-      case vdkError.vE_AuthFailure:
+      case udError.udE_AuthFailure:
         {
           this.message = "Invalid credentials, please try again.";
         }
         break;
 
-      case vdkError.vE_SecurityFailure:
+      case udError.udE_SecurityFailure:
         {
           // TODO alert screen with option to change setting
           this.message = "Security failure, try disabling cert verification.";
         }
         break;
 
-      case vdkError.vE_ProxyError:
+      case udError.udE_ProxyError:
         {
           this.message =
               "There was an issue with the provided proxy information.";

--- a/vaultSDK/lib/udConfig.dart
+++ b/vaultSDK/lib/udConfig.dart
@@ -15,24 +15,22 @@ class UdConfig {
 
   // Allows VDK to connect to server with an unrecognized certificate authority, sometimes required for self-signed certificates or poorly configured proxies.
   // Used for workaround where calling UdContext.connect will always return vE_SecurityFailure
-  static vdkError ignoreCertificateVerification(bool ignore) {
+  static udError ignoreCertificateVerification(bool ignore) {
     // Cast boolean to C int where 0 == False and 1 == True
-    int boolean = 0;
-    if (ignore) boolean = 1;
-    var err = udConfig_IgnoreCertificateVerification(boolean);
+    int ignoreVal = ignore ? 1 : 0;
+    var err = udConfig_IgnoreCertificateVerification(ignoreVal);
 
-    return vdkError.values[err];
+    return udError.values[err];
   }
 }
 
-// TODO change Int8 ignore -> Int32 ingore upon migration to udSDK
 typedef udConfig_IgnoreCertificateVerification_native = Int32 Function(
-    Int8 ignore);
+    Int32 ignore);
 typedef udConfig_IgnoreCertificateVerification_dart = int Function(int ignore);
 
 final udConfig_IgnoreCertificateVerificationPointer = vdkLib
     .lookup<NativeFunction<udConfig_IgnoreCertificateVerification_native>>(
-        'vdkConfig_IgnoreCertificateVerification');
+        'udConfig_IgnoreCertificateVerification');
 
 final udConfig_IgnoreCertificateVerification =
     udConfig_IgnoreCertificateVerificationPointer

--- a/vaultSDK/lib/udContext.dart
+++ b/vaultSDK/lib/udContext.dart
@@ -16,7 +16,7 @@ class UdContext {
   }
 
   // Call these functions in flutter widgets
-  static vdkError connect(Pointer<IntPtr> udContext, email, password,
+  static udError connect(Pointer<IntPtr> udContext, email, password,
       [url = 'https://udstream.euclideon.com', appName = 'Pointfluent']) {
     final uUrl = Utf8.toUtf8(url);
     final uAppName = Utf8.toUtf8(appName);
@@ -29,7 +29,7 @@ class UdContext {
     free(uEmail);
     free(uPassword);
 
-    return vdkError.values[err];
+    return udError.values[err];
   }
 }
 
@@ -49,7 +49,7 @@ typedef udContext_Connect_dart = int Function(
     Pointer<Utf8> password);
 
 final udContext_ConnectPointer = vdkLib
-    .lookup<NativeFunction<udContext_Connect_native>>('vdkContext_Connect');
+    .lookup<NativeFunction<udContext_Connect_native>>('udContext_Connect');
 
 final udContext_Connect =
     udContext_ConnectPointer.asFunction<udContext_Connect_dart>();

--- a/vaultSDK/lib/udError.dart
+++ b/vaultSDK/lib/udError.dart
@@ -1,40 +1,42 @@
-//!
-//! These are the various error codes returned by VDK functions
-//! @note The `0` value is success, this is different to many C APIs and as such `if(vdkFunction() == vE_Success)` is required to handle success cases.
-//!
-enum vdkError {
-  vE_Success, //!< Indicates the operation was successful
+/// These are the various error codes returned by udSDK functions
+///
+/// The `0` value is success, this is different to many C APIs and as such `if(udFunction() == udE_Success)` is required to handle success cases.
+enum udError {
+  udE_Success, //!< Indicates the operation was successful
 
-  vE_Failure, //!< A catch-all value that is rarely used, internally the below values are favored
-  vE_InvalidParameter, //!< One or more parameters is not of the expected format
-  vE_InvalidConfiguration, //!< Something in the request is not correctly configured or has conflicting settings
-  vE_InvalidLicense, //!< The required license isn't available or has expired
-  vE_SessionExpired, //!< The Vault Server has terminated your session
+  udE_Failure, //!< A catch-all value that is rarely used, internally the below values are favored
+  udE_InvalidParameter, //!< One or more parameters is not of the expected format
+  udE_InvalidConfiguration, //!< Something in the request is not correctly configured or has conflicting settings
+  udE_InvalidLicense, //!< The required license isn't available or has expired
+  udE_SessionExpired, //!< The udServer has terminated your session
 
-  vE_NotAllowed, //!< The requested operation is not allowed (usually this is because the operation isn't allowed in the current state)
-  vE_NotSupported, //!< This functionality has not yet been implemented (usually some combination of inputs isn't compatible yet)
-  vE_NotFound, //!< The requested item wasn't found or isn't currently available
-  vE_NotInitialized, //!< The request can't be processed because an object hasn't been configured yet
+  udE_NotAllowed, //!< The requested operation is not allowed (usually this is because the operation isn't allowed in the current state)
+  udE_NotSupported, //!< This functionality has not yet been implemented (usually some combination of inputs isn't compatible yet)
+  udE_NotFound, //!< The requested item wasn't found or isn't currently available
+  udE_NotInitialized, //!< The request can't be processed because an object hasn't been configured yet
 
-  vE_ConnectionFailure, //!< There was a connection failure
-  vE_MemoryAllocationFailure, //!< VDK wasn't able to allocate enough memory for the requested feature
-  vE_ServerFailure, //!< The server reported an error trying to fufil the request
-  vE_AuthFailure, //!< The provided credentials were declined (usually username or password issue)
-  vE_SecurityFailure, //!< There was an issue somewhere in the security system- usually creating or verifying of digital signatures or cryptographic key pairs
-  vE_OutOfSync, //!< There is an inconsistency between the internal VDK state and something external. This is usually because of a time difference between the local machine and a remote server
+  udE_ConnectionFailure, //!< There was a connection failure
+  udE_MemoryAllocationFailure, //!< udSDK wasn't able to allocate enough memory for the requested feature
+  udE_ServerFailure, //!< The server reported an error trying to fufil the request
+  udE_AuthFailure, //!< The provided credentials were declined (usually email or password issue)
+  udE_SecurityFailure, //!< There was an issue somewhere in the security system- usually creating or verifying of digital signatures or cryptographic key pairs
+  udE_OutOfSync, //!< There is an inconsistency between the internal udSDK state and something external. This is usually because of a time difference between the local machine and a remote server
 
-  vE_ProxyError, //!< There was some issue with the provided proxy information (either a proxy is in the way or the provided proxy info wasn't correct)
-  vE_ProxyAuthRequired, //!< A proxy has requested authentication
+  udE_ProxyError, //!< There was some issue with the provided proxy information (either a proxy is in the way or the provided proxy info wasn't correct)
+  udE_ProxyAuthRequired, //!< A proxy has requested authentication
 
-  vE_OpenFailure, //!< A requested resource was unable to be opened
-  vE_ReadFailure, //!< A requested resourse was unable to be read
-  vE_WriteFailure, //!< A requested resource was unable to be written
-  vE_ParseError, //!< A requested resource or input was unable to be parsed
-  vE_ImageParseError, //!< An image was unable to be parsed. This is usually an indication of either a corrupt or unsupported image format
+  udE_OpenFailure, //!< A requested resource was unable to be opened
+  udE_ReadFailure, //!< A requested resourse was unable to be read
+  udE_WriteFailure, //!< A requested resource was unable to be written
+  udE_ParseError, //!< A requested resource or input was unable to be parsed
+  udE_ImageParseError, //!< An image was unable to be parsed. This is usually an indication of either a corrupt or unsupported image format
 
-  vE_Pending, //!< A requested operation is pending.
-  vE_TooManyRequests, //!< This functionality is currently being rate limited or has exhausted a shared resource. Trying again later may be successful
-  vE_Cancelled, //!< The requested operation was cancelled (usually by the user)
+  udE_Pending, //!< A requested operation is pending.
+  udE_TooManyRequests, //!< This functionality is currently being rate limited or has exhausted a shared resource. Trying again later may be successful
+  udE_Cancelled, //!< The requested operation was cancelled (usually by the user)
+  udE_Timeout, //!< The requested operation timed out. Trying again later may be successful
+  udE_OutstandingReferences, //!< The requested operation failed because there are still references to this object
+  udE_ExceededAllowedLimit, //!< The requested operation failed because it would exceed the allowed limits (generally used for exceeding server limits like number of projects)
 
-  vE_Count //!< Internally used to verify return values
+  udE_Count //!< Internally used to verify return values
 }

--- a/vaultSDK/lib/vdkLib.dart
+++ b/vaultSDK/lib/vdkLib.dart
@@ -2,5 +2,5 @@ import 'dart:io';
 import 'dart:ffi';
 
 final DynamicLibrary vdkLib = Platform.isAndroid
-    ? DynamicLibrary.open("libvaultSDK.so")
+    ? DynamicLibrary.open("libudSDK.so")
     : DynamicLibrary.process();


### PR DESCRIPTION
I've migrated the function calls to work with the new udSDK with the function naming being correct.

I haven't renamed the vaultSDK folder/package yet because I can't seem to get it to work without breaking the build.
If someone wants to attempt this, go for it. Otherwise we just continue to import the package as `package:vaultSDK` until fixed so we can move on.