### PR TITLE
Fixed home screen styling

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -15,6 +15,6 @@ jobs:
         java-version: '12.x'
     - uses: subosito/flutter-action@v1
       with:
-        flutter-version: '1.17.5'
+        flutter-version: '1.20.2'
     - run: flutter pub get
     - run: flutter build apk

--- a/lib/auth/home.dart
+++ b/lib/auth/home.dart
@@ -1,3 +1,4 @@
+import 'package:Pointfluent/widgets/menuItem.dart';
 import 'package:flutter/material.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/services.dart';
@@ -60,56 +61,18 @@ class _HomePageState extends State<HomePage> {
               trailing: Icon(Icons.keyboard_arrow_right, color: Colors.white),
             ),
           ),
-          Container(
-            margin: const EdgeInsets.only(top: 12),
-            color: Color(0xffffffff),
-            child: ListTile(
-              title: Text(
-                'Most Recent',
-                style: const TextStyle(fontSize: 16, letterSpacing: -0.3),
-              ),
-              // leading: Icon(Icons.storage),
+          MenuItem(
+              title: 'Most Recent',
               trailing: Icon(Icons.keyboard_arrow_right),
-            ),
-          ),
-          Container(
-            margin: const EdgeInsets.only(top: 12),
-            color: Color(0xffffffff),
-            child: ListTile(
-                title: Text(
-                  'Select File',
-                  style: const TextStyle(
-                    fontSize: 22,
-                  ),
-                ),
-                leading: Icon(Icons.folder),
-                trailing: Icon(Icons.keyboard_arrow_right),
-                onTap: () => _handleFileSelect()),
-          ),
-          Card(
-            child: ListTile(
-              title: Text(
-                'Settings',
-                style: const TextStyle(fontSize: 16, letterSpacing: -0.3),
-              ),
-              // leading: Icon(Icons.settings),
+              onTap: () => _handleFileSelect()),
+          MenuItem(
+              title: 'Settings',
               trailing: Icon(Icons.keyboard_arrow_right),
-              onTap: () => Navigator.pushNamed(context, '/settings'),
-            ),
-          ),
-          Container(
-            margin: const EdgeInsets.only(top: 12),
-            color: Color(0xffffffff),
-            child: ListTile(
-              title: Text(
-                'Logout',
-                style: const TextStyle(fontSize: 16, letterSpacing: -0.3),
-              ),
-              // leading: Icon(Icons.eject),
+              onTap: () => Navigator.pushNamed(context, '/settings')),
+          MenuItem(
+              title: 'Logout',
               trailing: Icon(Icons.keyboard_arrow_right),
-              onTap: () => Navigator.popAndPushNamed(context, '/'),
-            ),
-          ),
+              onTap: () => Navigator.popAndPushNamed(context, '/')),
           ErrorMsg(message: _errMessage),
         ],
       ),

--- a/lib/auth/home.dart
+++ b/lib/auth/home.dart
@@ -40,24 +40,41 @@ class _HomePageState extends State<HomePage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      backgroundColor: Color(0xfff8f8f8),
       appBar: AppBar(
-        title: const Text('Home'),
+        toolbarHeight: 80,
+        elevation: 0,
+        title:
+            Text('Home', style: TextStyle(color: Colors.white, fontSize: 26)),
       ),
       body: ListView(
         children: <Widget>[
-          Card(
+          Container(
+            color: Color.fromRGBO(24, 189, 210, 1.0),
+            child: ListTile(
+              title: Text(
+                'Enter Scene Viewer',
+                style: const TextStyle(
+                    color: Colors.white, fontSize: 18, letterSpacing: -0.3),
+              ),
+              trailing: Icon(Icons.keyboard_arrow_right, color: Colors.white),
+            ),
+          ),
+          Container(
+            margin: const EdgeInsets.only(top: 12),
+            color: Color(0xffffffff),
             child: ListTile(
               title: Text(
                 'Most Recent',
-                style: const TextStyle(
-                  fontSize: 22,
-                ),
+                style: const TextStyle(fontSize: 16, letterSpacing: -0.3),
               ),
-              leading: Icon(Icons.storage),
+              // leading: Icon(Icons.storage),
               trailing: Icon(Icons.keyboard_arrow_right),
             ),
           ),
-          Card(
+          Container(
+            margin: const EdgeInsets.only(top: 12),
+            color: Color(0xffffffff),
             child: ListTile(
                 title: Text(
                   'Select File',
@@ -73,24 +90,22 @@ class _HomePageState extends State<HomePage> {
             child: ListTile(
               title: Text(
                 'Settings',
-                style: const TextStyle(
-                  fontSize: 22,
-                ),
+                style: const TextStyle(fontSize: 16, letterSpacing: -0.3),
               ),
-              leading: Icon(Icons.settings),
+              // leading: Icon(Icons.settings),
               trailing: Icon(Icons.keyboard_arrow_right),
               onTap: () => Navigator.pushNamed(context, '/settings'),
             ),
           ),
-          Card(
+          Container(
+            margin: const EdgeInsets.only(top: 12),
+            color: Color(0xffffffff),
             child: ListTile(
               title: Text(
                 'Logout',
-                style: const TextStyle(
-                  fontSize: 22,
-                ),
+                style: const TextStyle(fontSize: 16, letterSpacing: -0.3),
               ),
-              leading: Icon(Icons.eject),
+              // leading: Icon(Icons.eject),
               trailing: Icon(Icons.keyboard_arrow_right),
               onTap: () => Navigator.popAndPushNamed(context, '/'),
             ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,6 +20,7 @@ class MyApp extends StatelessWidget {
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
+    // Custom material color data
     Map<int, Color> color = {
       50: Color.fromRGBO(18, 171, 199, .1),
       100: Color.fromRGBO(18, 171, 199, .2),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,10 +20,25 @@ class MyApp extends StatelessWidget {
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
+    Map<int, Color> color = {
+      50: Color.fromRGBO(18, 171, 199, .1),
+      100: Color.fromRGBO(18, 171, 199, .2),
+      200: Color.fromRGBO(18, 171, 199, .3),
+      300: Color.fromRGBO(18, 171, 199, .4),
+      400: Color.fromRGBO(18, 171, 199, .5),
+      500: Color.fromRGBO(18, 171, 199, .6),
+      600: Color.fromRGBO(18, 171, 199, .7),
+      700: Color.fromRGBO(18, 171, 199, .8),
+      800: Color.fromRGBO(18, 171, 199, .9),
+      900: Color.fromRGBO(18, 171, 199, 1),
+    };
+
+    MaterialColor customColor = MaterialColor(0xff12abc7, color);
+
     return MaterialApp(
         title: 'Flutter Demo',
         theme: ThemeData(
-          primarySwatch: Colors.cyan,
+          primarySwatch: customColor,
           visualDensity: VisualDensity.adaptivePlatformDensity,
         ),
         initialRoute: '/',

--- a/lib/widgets/menuItem.dart
+++ b/lib/widgets/menuItem.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+class MenuItem extends StatelessWidget {
+  final String title;
+  final Widget trailing;
+  final GestureTapCallback onTap;
+
+  MenuItem({this.title, this.trailing, this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      margin: const EdgeInsets.only(top: 12),
+      color: Colors.white,
+      child: ListTile(
+        title: Text(
+          this.title,
+          style: const TextStyle(fontSize: 16, letterSpacing: -0.3),
+        ),
+        trailing: this.trailing,
+        onTap: onTap,
+      ),
+    );
+  }
+}

--- a/lib/widgets/menuItem.dart
+++ b/lib/widgets/menuItem.dart
@@ -18,7 +18,7 @@ class MenuItem extends StatelessWidget {
           style: const TextStyle(fontSize: 16, letterSpacing: -0.3),
         ),
         trailing: this.trailing,
-        onTap: onTap,
+        onTap: this.onTap,
       ),
     );
   }


### PR DESCRIPTION
Fixed styling of home screen to match with the UI mockups. 
Haven't implemented a file picker yet though. 

The `primarySwatch` property in ThemeData only allowed material colors so I couldn't set the specific color used in the mockup, but I found a workaround [here](https://medium.com/flutterworld/flutter-material-color-conversion-ad1574f25828).

![homescreen](https://user-images.githubusercontent.com/24802707/91662510-3f35da80-eb26-11ea-8401-b614714454a7.png)
