### PR TITLE
Fixed logout causing thrown exeception

### DIFF
--- a/lib/auth/home.dart
+++ b/lib/auth/home.dart
@@ -21,8 +21,16 @@ class HomePage extends StatefulWidget {
 }
 
 class _HomePageState extends State<HomePage> {
-  ErrorMsg _error = ErrorMsg();
+  ErrorMsg _error;
+  bool logoutLoading;
   static const double marginTop = 12;
+
+  @override
+  void initState() {
+    _error = ErrorMsg();
+    logoutLoading = false;
+    super.initState();
+  }
 
   void _handleFileSelect() async {
     var filePath = await FilePicker.getFilePath(type: FileType.any);
@@ -38,6 +46,7 @@ class _HomePageState extends State<HomePage> {
   }
 
   _handleLogout(context) async {
+    setState(() => logoutLoading = true);
     await widget.udManager.logout();
     Navigator.popAndPushNamed(context, '/');
   }
@@ -82,6 +91,7 @@ class _HomePageState extends State<HomePage> {
             trailing: Icon(Icons.keyboard_arrow_right),
             onTap: () => _handleLogout(context),
             margin: const EdgeInsets.only(top: marginTop),
+            isLoading: logoutLoading,
           ),
         ],
       ),

--- a/lib/auth/home.dart
+++ b/lib/auth/home.dart
@@ -1,6 +1,7 @@
 import 'package:Pointfluent/widgets/menuItem.dart';
 import 'package:flutter/material.dart';
 import 'package:file_picker/file_picker.dart';
+import 'package:vaultSDK/udManager.dart';
 import 'package:flutter/services.dart';
 import 'dart:io';
 import 'dart:async';
@@ -10,7 +11,9 @@ import '../widgets/ErrorMsg.dart';
 import '../auth/sceneViewer.dart';
 
 class HomePage extends StatefulWidget {
-  HomePage({Key key}) : super(key: key);
+  final UdManager udManager;
+
+  HomePage({Key key, this.udManager}) : super(key: key);
   static const routeName = '/home';
 
   @override
@@ -32,6 +35,11 @@ class _HomePageState extends State<HomePage> {
       SceneViewerPage.routeName,
       arguments: SceneViewerArgs(filePath),
     );
+  }
+
+  _handleLogout(context) async {
+    await widget.udManager.logout();
+    Navigator.popAndPushNamed(context, '/');
   }
 
   @override
@@ -58,20 +66,23 @@ class _HomePageState extends State<HomePage> {
             ),
           ),
           MenuItem(
-              title: 'Most Recent',
-              trailing: Icon(Icons.keyboard_arrow_right),
-              onTap: () => _handleFileSelect(),
-              margin: const EdgeInsets.only(top: marginTop),),
+            title: 'Most Recent',
+            trailing: Icon(Icons.keyboard_arrow_right),
+            onTap: () => _handleFileSelect(),
+            margin: const EdgeInsets.only(top: marginTop),
+          ),
           MenuItem(
-              title: 'Settings',
-              trailing: Icon(Icons.keyboard_arrow_right),
-              onTap: () => Navigator.pushNamed(context, '/settings'),
-              margin: const EdgeInsets.only(top: marginTop),),
+            title: 'Settings',
+            trailing: Icon(Icons.keyboard_arrow_right),
+            onTap: () => Navigator.pushNamed(context, '/settings'),
+            margin: const EdgeInsets.only(top: marginTop),
+          ),
           MenuItem(
-              title: 'Logout',
-              trailing: Icon(Icons.keyboard_arrow_right),
-              onTap: () => Navigator.popAndPushNamed(context, '/'),
-              margin: const EdgeInsets.only(top: marginTop),),
+            title: 'Logout',
+            trailing: Icon(Icons.keyboard_arrow_right),
+            onTap: () => _handleLogout(context),
+            margin: const EdgeInsets.only(top: marginTop),
+          ),
         ],
       ),
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -50,7 +50,9 @@ class MyApp extends StatelessWidget {
           LoginPage.routeName: (context) => LoginPage(
                 udManager: udManager,
               ),
-          HomePage.routeName: (context) => HomePage(),
+          HomePage.routeName: (context) => HomePage(
+                udManager: udManager,
+              ),
           SceneViewerPage.routeName: (context) => SceneViewerPage(
                 udManager: udManager,
               ),

--- a/lib/widgets/menuItem.dart
+++ b/lib/widgets/menuItem.dart
@@ -5,8 +5,10 @@ class MenuItem extends StatelessWidget {
   final Widget trailing;
   final GestureTapCallback onTap;
   final EdgeInsetsGeometry margin;
+  final bool isLoading;
 
-  MenuItem({this.title, this.trailing, this.onTap, this.margin});
+  MenuItem({this.title, this.trailing, this.onTap, this.margin, bool isLoading})
+      : this.isLoading = isLoading ?? false;
 
   @override
   Widget build(BuildContext context) {
@@ -18,7 +20,7 @@ class MenuItem extends StatelessWidget {
           this.title,
           style: const TextStyle(fontSize: 16, letterSpacing: -0.3),
         ),
-        trailing: this.trailing,
+        trailing: this.isLoading ? CircularProgressIndicator() : this.trailing,
         onTap: this.onTap,
       ),
     );

--- a/vaultSDK/lib/udManager.dart
+++ b/vaultSDK/lib/udManager.dart
@@ -69,7 +69,7 @@ class _UdManager extends UdSDKClass {
   @override
   void dispose() {
     pointCloud.unLoad();
-    renderTarget.destroy();
+    renderTarget?.destroy();
     renderContext.destroy();
     udContext.disconnect();
     super.dispose();
@@ -199,10 +199,11 @@ class UdManager extends UdSDKClass {
   ReceivePort _mainRPort;
   SendPort _echoPort;
 
-  UdManager() : this._mainRPort = ReceivePort();
+  UdManager();
 
   /// spawn the child Isolate and get the sendPort
   Future setup() async {
+    this._mainRPort = ReceivePort();
     await Isolate.spawn(_spawnIsolate, _mainRPort.sendPort);
     _echoPort = await _mainRPort.first;
   }
@@ -254,6 +255,10 @@ class UdManager extends UdSDKClass {
   /// Render the loaded model and return the resulting color buffer
   Future<ByteBuffer> render() async {
     return await _sendFunction(ExecutableFunction(ManagerFns.render, []));
+  }
+
+  Future<void> logout() async {
+    await this.cleanup();
   }
 
   /// Free associated memory and close the child Isolate

--- a/vaultSDK/lib/udPointCloud.dart
+++ b/vaultSDK/lib/udPointCloud.dart
@@ -10,10 +10,12 @@ import 'udContext.dart';
 class UdPointCloud extends UdSDKClass {
   Pointer<IntPtr> _pointCloud;
   udPointCloudHeader header;
+  bool loaded;
 
   UdPointCloud() {
     this._pointCloud = allocate();
     this.header = udPointCloudHeader.allocate();
+    this.loaded = false;
     _nullChecks();
     setMounted();
   }
@@ -32,12 +34,16 @@ class UdPointCloud extends UdSDKClass {
     free(pModelLocation);
 
     handleUdError(err);
+    this.loaded = true;
   }
 
   /// Destroys the udPointCloud.
   void unLoad() {
     checkMounted();
-    handleUdError(_udPointCloud_Unload(this._pointCloud));
+    if (loaded) {
+      handleUdError(_udPointCloud_Unload(this._pointCloud));
+    }
+    this.dispose();
   }
 
   /// Update the udPointCloudHeader of this class
@@ -50,7 +56,6 @@ class UdPointCloud extends UdSDKClass {
   void dispose() {
     checkMounted();
     free(this._pointCloud);
-    free(this.header.attributes[0].pDescriptors);
     free(this.header.addressOf);
     super.dispose();
   }

--- a/vaultSDK/lib/udRenderContext.dart
+++ b/vaultSDK/lib/udRenderContext.dart
@@ -13,6 +13,7 @@ class UdRenderContext extends UdSDKClass {
   udRenderInstance renderInstance;
   udRenderSettings renderSettings;
   udRenderPicking renderPicking;
+  bool loaded; // true if this.create() has been called.
 
   UdRenderContext() {
     this._renderContext = allocate();
@@ -20,6 +21,7 @@ class UdRenderContext extends UdSDKClass {
     this.renderInstance = udRenderInstance.allocate();
     this.renderPicking = udRenderPicking.allocate();
     this.renderSettings = udRenderSettings.allocate();
+    this.loaded = false;
     _nullChecks();
     setMounted();
   }
@@ -37,12 +39,15 @@ class UdRenderContext extends UdSDKClass {
   void create(UdContext udContext) {
     checkMounted();
     handleUdError(_udRenderContext_Create(udContext.address, _renderContext));
+    this.loaded = true;
   }
 
   /// Destroy the instance of the renderer
   void destroy() {
     checkMounted();
-    handleUdError(_udRenderContext_Destroy(_renderContext));
+    if (loaded) {
+      handleUdError(_udRenderContext_Destroy(_renderContext));
+    }
     this.dispose();
   }
 

--- a/vaultSDK/lib/udRenderTarget.dart
+++ b/vaultSDK/lib/udRenderTarget.dart
@@ -17,12 +17,14 @@ class UdRenderTarget extends UdSDKClass {
   final int width;
   final int height;
   final int _bufferLength;
+  bool loaded; // true if this.create() has been called.
 
   UdRenderTarget(this.width, this.height)
       : this._bufferLength = width * height {
     this._renderTarget = allocate();
     this._colorBuffer = allocate(count: _bufferLength);
     this._depthBuffer = allocate(count: _bufferLength);
+    this.loaded = false;
 
     _nullChecks();
     setMounted();
@@ -55,12 +57,15 @@ class UdRenderTarget extends UdSDKClass {
       this.width,
       this.height,
     ));
+    this.loaded = true;
   }
 
   /// Destroys the instance of `ppRenderTarget`.
   void destroy() {
     checkMounted();
-    handleUdError(_udRenderTarget_Destroy(_renderTarget));
+    if (this.loaded) {
+      handleUdError(_udRenderTarget_Destroy(_renderTarget));
+    }
     this.dispose();
   }
 


### PR DESCRIPTION
Can now logout properly with proper cleanup of udSDK. The user will be returned to the login screen.

Added some safety checks that check for initialization & creation of the udSDK objects when cleanup() is called. 

Logout `MenuItem` has a loading spinner while waiting for the logout to complete.

Resolves #18 
